### PR TITLE
Add badges and reactions documentation

### DIFF
--- a/src/app/navigation.json
+++ b/src/app/navigation.json
@@ -43,6 +43,16 @@
         "type": "route",
         "path": "security",
         "label": "Security"
+      },
+      {
+        "type": "route",
+        "path": "badges",
+        "label": "Badges"
+      },
+      {
+        "type": "route",
+        "path": "reactions",
+        "label": "Reactions"
       }
     ]
   },

--- a/src/app/user-manual/admin-panel/page.mdx
+++ b/src/app/user-manual/admin-panel/page.mdx
@@ -66,10 +66,10 @@ On the settings page you can find all of the components that are less frequently
 Here you can find:
 - Api clients
 - <Link href="/user-manual/automation">Automations</Link>,
-- Badges,
+- <Link href="/user-manual/badges">Badges</Link>,
 - <Link href="/user-manual/identity-provider">Identity providers</Link>,
 - <Link href="/user-manual/menu-builder">Menu Builder</Link>,
 - Plugins,
-- Reactions,
+- <Link href="/user-manual/reactions">Reactions</Link>,
 - <Link href="/user-manual/security">Roles</Link>,
 - Themes.

--- a/src/app/user-manual/badges/page.mdx
+++ b/src/app/user-manual/badges/page.mdx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { Wrench } from '@phosphor-icons/react/dist/ssr';
+
+# Badges
+
+Badges are awards you can create and assign to users to recognize achievements, contributions, or membership status.
+They are displayed on a user's profile page and can optionally appear next to the user's name in forum posts.
+
+## Managing Badges
+
+Badges are managed in the <Link href="/user-manual/admin-panel">Admin Panel</Link> under <Wrench /> Settings -> Badges.
+
+When creating or editing a badge, you can configure the following fields:
+
+- **Name**: The name of the badge.
+- **Description**: An optional description explaining what the badge is for.
+- **Image**: An image representing the badge. The recommended size is 64x64 pixels.
+- **Show on Forum**: When enabled, the badge will be displayed next to the user's name on forum posts in addition to their profile page.
+
+## Assigning Badges
+
+Badges can be assigned to users in two ways:
+
+### Manually
+
+Open the user in the <Link href="/user-manual/admin-panel">Admin Panel</Link> under Users, then use the "Manage Badges" option to add or remove badges from that user.
+
+### Via Automation
+
+Badges can be assigned automatically using the **Give Badge** action in <Link href="/user-manual/automation">Automations</Link>.
+This allows you to award badges based on events, such as when a user creates their first topic or reaches a certain post count.
+
+When a user receives a badge, they are notified automatically.

--- a/src/app/user-manual/reactions/page.mdx
+++ b/src/app/user-manual/reactions/page.mdx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { Wrench } from '@phosphor-icons/react/dist/ssr';
+
+# Reactions
+
+Reactions allow users to respond to forum comments with an image, similar to emoji reactions on other platforms.
+Each reaction can be configured to affect the reputation of the comment's author.
+
+## Managing Reactions
+
+Reactions are managed in the <Link href="/user-manual/admin-panel">Admin Panel</Link> under <Wrench /> Settings -> Reactions.
+
+When creating or editing a reaction, you can configure the following fields:
+
+- **Name**: The name of the reaction (e.g. "Like", "Thanks", "Disagree").
+- **Image**: An image representing the reaction. The recommended size is 64x64 pixels.
+- **Reputation**: The reputation impact when a user uses this reaction on a comment:
+  - **Positive**: Adds 1 to the author's reputation.
+  - **Neutral**: No reputation change.
+  - **Negative**: Subtracts 1 from the author's reputation.
+
+## User Experience
+
+Reactions appear below each forum comment. Users can click a reaction to add it, or click it again to remove it.
+The total count for each reaction is shown next to the reaction image, allowing the community to express sentiment at a glance.


### PR DESCRIPTION
Adds User Manual pages for badges and reactions, and links them from the Admin Panel settings list.